### PR TITLE
Unittests

### DIFF
--- a/fletcher/algorithms/string.py
+++ b/fletcher/algorithms/string.py
@@ -271,8 +271,11 @@ def _text_contains_case_sensitive(data: pa.Array, pat: str) -> pa.Array:
 @njit
 def _get_zstring(width: int, buffer: np.ndarray, temp_buffer: np.ndarray) -> np.ndarray:
     num_zeros = width
-    for i in np.bitwise_xor(np.right_shift(buffer, 6), 2):
-        if i != 0:
+    mask = 192  # corresponds to 11000000
+    for i in np.bitwise_and(buffer, mask):
+        if (
+            i != 128
+        ):  # is 10000000 -> 10xxxxxx corresponds to neither utf-8 nor ascii character
             num_zeros -= 1
     if num_zeros <= 0:
         return buffer

--- a/fletcher/algorithms/string.py
+++ b/fletcher/algorithms/string.py
@@ -270,6 +270,10 @@ def _text_contains_case_sensitive(data: pa.Array, pat: str) -> pa.Array:
 
 @njit
 def _get_zstring(width: int, buffer: np.ndarray, temp_buffer: np.ndarray) -> np.ndarray:
+    """
+    Compute length of a bytestring in ``buffer``, prepend with '0' characters up to ``width``
+    (inside of ``temp_buffer``) and fill the rest of ``temp_buffer`` with actual string values.
+    """
     num_zeros = width
     mask = 192  # corresponds to 11000000
     for i in np.bitwise_and(buffer, mask):
@@ -326,6 +330,7 @@ def _zfill_nulls(
         if not valid:
             str_builder.append_null()
             continue
+
         value = _get_zstring(
             width, data_buffer[offsets[row_idx] : offsets[row_idx + 1]], temp_val_buffer
         )
@@ -334,6 +339,11 @@ def _zfill_nulls(
 
 @apply_per_chunk
 def _zfill(data: pa.Array, width: int) -> pa.Array:
+    """
+    Prepend each element in the data with '0' characters up to ``width``.
+
+    Nulls remain unchanged.
+    """
     offsets, data_buffer = _extract_string_buffers(data)
     str_builder = StringArrayBuilder(max(len(data_buffer), 2))
 

--- a/fletcher/string_array.py
+++ b/fletcher/string_array.py
@@ -351,7 +351,29 @@ class TextAccessor:
         return self._call_str_accessor("contains", pat=pat, case=case, regex=regex)
 
     def zfill(self, width: int) -> pd.Series:
-        """Pad strings in the Series/Index by prepending '0' characters."""
+        """
+        Pad strings in the Series/Index by prepending '0' characters.
+
+        Return string Series or Index with prepended '0' characters to each string. The final length
+        of each string coincides with width.
+
+        The behaviour does not differ from the one in ``pandas``:
+         * Doesn't have a special handling for ``-`` / ``+`` at the start of string.
+         * If length of a string is greater than width, the string will remain unchanged.
+
+        Parameters
+        ----------
+        width : int
+            Final length of string, up to which the '0' characters will be prepended.
+
+            If less or equal 0: All strings remain unchanged.
+
+        Returns
+        -------
+        Series or Index of string values
+            A Series or Index of string values with prepended '0' characters
+            to each string (up to width).
+        """
         if width < 1 or not len(self.data):
             return self._series_like(self.data)
         return self._series_like(_zfill(self.data, width))

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -168,3 +168,25 @@ def test_text_zfill(data, fletcher_variant):
     # Pandas returns np.nan for NA values in cat, keep this in line
     result_fr[result_fr.isna()] = np.nan
     tm.assert_series_equal(result_fr, result_pd)
+
+
+@pytest.mark.parametrize(
+    "data, width, expected",
+    [
+        ([], -1, []),
+        ([None], 7, [None]),
+        ([""], 3, ["000"]),
+        (
+            ["a", "_xyz", "aBcDe", "ä", None, "æ", "-01", "+1"],
+            4,
+            ["000a", "_xyz", "aBcDe", "000ä", None, "000æ", "0-01", "00+1"],
+        ),
+    ],
+)
+def test_zfill_simple(data, width, expected, fletcher_variant):
+    fr_series = _fr_series_from_data(data, fletcher_variant)
+    fr_expected = _fr_series_from_data(expected, fletcher_variant, pa.string())
+
+    for i in range(len(data)):
+        result = fr_series.fr_text.zfill(width)
+        tm.assert_series_equal(result, fr_expected)


### PR DESCRIPTION
This PR adds/changes:

* Change bit mask logic for getting length of a byte string: Use of `np.bitwise_and` showed an (insignificant) improvement in performance;
* Add a couple of docstrings;
* Add a simple test for testing some edge cases. I am not completely sure, if we need the test, though (since we have a `hypothesis`-ed test for `zfill` already).